### PR TITLE
Fix Bug Where Deleting Tag Would Cause Home Page to Crash

### DIFF
--- a/imports/ui/reducers/index.js
+++ b/imports/ui/reducers/index.js
@@ -165,6 +165,16 @@ const songsReducer = (
             : song;
         })
       };
+    case 'DELETE_TAG':
+      return {
+        ...state,
+        songs: state.songs.map(song => {
+          return {
+            ...song,
+            tags: song.tags.filter(id => id !== action.payload)
+          };
+        })
+      };
     default:
       return state;
   }


### PR DESCRIPTION
- https://github.com/achin797/tagify/issues/29

The app is crashing because we are deleting a tag that is associated with a song. The song still had the tag, but because the tag doesn't exist anymore, we cannot get its `displayName` property.

The fix is to remove the tag from all songs that have it when the tag is deleted.