### PR TITLE
Create playlist implemented. Just basics for now

### DIFF
--- a/imports/startup/server/methods.js
+++ b/imports/startup/server/methods.js
@@ -20,23 +20,26 @@ Meteor.methods({
 
         return response.data.body.tracks.items;
     },
-    createPlaylist: function(selectedTracks, playlistName) {
+
+    //TODO: Add error case handling and better playlist naming
+    createPlaylist: function(playlistName, selectedTracks) {
         if (!selectedTracks || !playlistName || selectedTracks.length > 20) throw new Error("No tracks or playlist name specified");
 
         // Call
         var spotifyApi = new SpotifyWebApi();
-        var response = spotifyApi.createPlaylist(Meteor.user().services.spotify.id, playlistName, { public: false });
+        var response = spotifyApi.createPlaylist(Meteor.user().services.spotify.id, playlistName, { public: true });
 
         // Need to refresh token
         if (checkTokenRefreshed(response, spotifyApi)) {
-            response = spotifyApi.createPlaylist(Meteor.user().services.spotify.id, playlistName, { public: false });
+            response = spotifyApi.createPlaylist(Meteor.user().services.spotify.id, playlistName, { public: true });
         }
 
         // Put songs into the playlist.
         var uris = selectedTracks.map(function(track) {
-            return track.uri;
+            return "spotify:track:"+track.id;
         });
-        spotifyApi.addTracksToPlaylist(Meteor.user().services.spotify.id, response.data.body.id, uris, {});
+
+        response = spotifyApi.addTracksToPlaylist(Meteor.user().services.spotify.id, response.data.body.id, uris, {});
 
         return response.data.body;
     },

--- a/imports/ui/actions/index.js
+++ b/imports/ui/actions/index.js
@@ -88,9 +88,9 @@ export const addTagToSong = (songId, tagId) => {
   };
 };
 
-export const addSongs = songs => {
+export const loadSongs = songs => {
     return {
-        type: 'ADD_SONGS',
+        type: 'LOAD_SONGS',
         payload: songs,
     };
 };

--- a/imports/ui/components/SongList.jsx
+++ b/imports/ui/components/SongList.jsx
@@ -1,35 +1,54 @@
-import React from 'react'
+import React, {Component} from 'react'
 import { connect } from 'react-redux';
 import List from 'antd/lib/list';
 import TaggableSong from './TaggableSong';
+import {loadSongs} from "../actions";
 
-const SongList = ({
-  songs,
-  checkedTags
-}) => {
-  const dataSource = checkedTags.length === 0
-    ? songs
-    : songs.filter(song => {
-      return song.tags.some(tag => {
-        return checkedTags.includes(tag);
-      })
-    });
+class SongList extends Component{
+  constructor(props){
+    super(props);
+  }
 
-  return (
-    <div id="song-list">
-      <List
-        dataSource={dataSource}
-        renderItem={song => <TaggableSong song={song} />}
-      />
-    </div>
-  );
-};
+  componentDidMount() {
+
+    //Use local state to avoid repeated api calls
+
+    if(!this.props.hasLoaded) {
+      Meteor.call("getSavedTracks", (err, response) => {
+          console.log("This message should only display on initial load");
+          this.props.loadSongs(response);
+        }
+      )
+    }
+  }
+
+  render(){
+    const dataSource = this.props.checkedTags.length === 0
+      ? this.props.songs
+      : this.props.songs.filter(song => {
+        return song.tags.some(tag => {
+          return this.props.checkedTags.includes(tag);
+        })
+      });
+
+    return (
+      <div id="song-list">
+        <List
+          loading={!this.props.hasLoaded}
+          dataSource={dataSource}
+          renderItem={song => <TaggableSong song={song} />}
+        />
+      </div>
+    );
+  }
+}
 
 const mapStateToProps = state => {
   return {
     songs: state.songs.songs,
+    hasLoaded: state.songs.hasLoaded,
     checkedTags: state.tagsPanel.checkedTags
   };
 };
 
-export default connect(mapStateToProps, {})(SongList);
+export default connect(mapStateToProps, {loadSongs})(SongList);

--- a/imports/ui/components/TaggableSong.jsx
+++ b/imports/ui/components/TaggableSong.jsx
@@ -79,7 +79,7 @@ class TaggableSong extends Component {
             {song.title}
           </div>
           <div>
-            <span>{song.artist} - {song.album}</span>
+            <span>{song.artists.join(", ")} - {song.album}</span>
           </div>
           <div>
             {song.tags.map((tagId, index) => {

--- a/imports/ui/pages/AuthPageSignIn.jsx
+++ b/imports/ui/pages/AuthPageSignIn.jsx
@@ -105,7 +105,8 @@ const mapDispatchToProps = dispatch => {
         requestPermissions: [
           'user-read-email',
           'user-library-read',
-          'user-library-modify'
+          'user-library-modify',
+          'playlist-modify-public'
         ]
       };
       Meteor.loginWithSpotify(signInOptions, err => {

--- a/imports/ui/pages/HomePage.jsx
+++ b/imports/ui/pages/HomePage.jsx
@@ -5,17 +5,28 @@ import Typography from 'antd/lib/typography';
 import Navbar from '../components/Navbar';
 import TagsPanel from '../components/TagsPanel';
 import SongList from '../components/SongList';
+import {Button} from "antd";
+import {connect} from "react-redux";
 
 const { Title } = Typography;
 
 class HomePage extends Component{
-    render(){
+  render(){
         return (
             <div id="home-page">
                 <Layout>
                     <Navbar />
                     <Layout>
-                        <TagsPanel />
+                        <span>
+                          <TagsPanel />
+                          <Button
+                            className="generate-playlist-button"
+                            type="primary"
+                            disabled={this.props.checkedTags.length === 0}
+                            onClick={() => this.createPlaylist()}>
+                            generate playlist
+                          </Button>
+                        </span>
                         <Divider />
                         <Title>Liked Songs</Title>
                         <SongList />
@@ -26,4 +37,10 @@ class HomePage extends Component{
     }
 }
 
-export default HomePage;
+const mapStateToProps = state => {
+  return {
+    checkedTags: state.tagsPanel.checkedTags
+  };
+};
+
+export default connect(mapStateToProps, {})(HomePage);

--- a/imports/ui/pages/HomePage.jsx
+++ b/imports/ui/pages/HomePage.jsx
@@ -11,6 +11,24 @@ import {connect} from "react-redux";
 const { Title } = Typography;
 
 class HomePage extends Component{
+
+  createPlaylist(){
+    let playlistName = this.props.checkedTags.join(", ");
+
+    //fetching the songs to add to playlist based on selected tags
+    let selected_songs = this.props.songs.filter(song => {
+      return song.tags.some(tag => {
+        return this.props.checkedTags.includes(tag);
+      })
+    });
+
+    Meteor.call("createPlaylist", playlistName, selected_songs, (err, response) => {
+        console.log("This message should only display after playlist creation");
+        console.log(response);
+      }
+    )
+  }
+
   render(){
         return (
             <div id="home-page">
@@ -39,7 +57,8 @@ class HomePage extends Component{
 
 const mapStateToProps = state => {
   return {
-    checkedTags: state.tagsPanel.checkedTags
+    checkedTags: state.tagsPanel.checkedTags,
+    songs: state.songs.songs
   };
 };
 

--- a/imports/ui/reducers/index.js
+++ b/imports/ui/reducers/index.js
@@ -7,50 +7,7 @@ function* idGenerator() {
   }
 }
 
-const id = idGenerator();
 const songs = [];
-songs.push({
-  id: id.next().value,
-  title: 'Intergalactic',
-  artist: 'Beastie Boys',
-  album: 'Hello Nasty',
-  tags: []
-});
-songs.push({
-  id: id.next().value,
-  title: 'Flamingo',
-  artist: 'Kero Kero Bonito',
-  album: 'shh#ffb6c1',
-  tags: []
-});
-songs.push({
-  id: id.next().value,
-  title: 'Price Tag',
-  artist: 'Jessie J ft. B.o.B',
-  album: 'Who You Are',
-  tags: []
-});
-songs.push({
-  id: id.next().value,
-  title: `God's Plan`,
-  artist: 'Drake',
-  album: 'Scorpion',
-  tags: []
-});
-songs.push({
-  id: id.next().value,
-  title: 'Outside with the Cuties',
-  artist: 'Frankie Cosmos',
-  album: 'Next Thing',
-  tags: []
-});
-songs.push({
-  id: id.next().value,
-  title: 'Lose Yourself',
-  artist: 'Eminem',
-  album: '8 Mile',
-  tags: []
-});
 
 const tagsPanelReducer = (
   state = {
@@ -152,11 +109,18 @@ const tagsReducer = (
 
 const songsReducer = (
   state = {
+    hasLoaded: false,
     songs
   },
   action
 ) => {
   switch (action.type) {
+    case 'LOAD_SONGS':
+      return {
+        ...state,
+        hasLoaded: true,
+        songs: action.payload
+      };
     case 'ADD_TAG_TO_SONG':
       return {
         ...state,


### PR DESCRIPTION
What's added:
• Button to generate playlist.
• Playlist creation based on selected tags.

How to test:
> Log in to the app. 
> Once you're successfully logged in and your songs load create some tags if they don't exist. 
> Add those tags to some songs. 
> Select those tags to filter the song list. 
> Click on generate playlist. 
> Once that's done, open Spotify on your phone or computer and you should see a new playlist with the tagged songs.

What's left:
• A tool-tip to display on hover over a disabled playlist button to tell user to select tags in order to generate a playlist.
• Error handling for create playlist.
• Playlist naming - Right now it's just ugly numbers.
• Bypassing the 100 songs limit for adding a playlist. For now we can only add 100 songs to a playlist.
• Preventing a user to create a playlist with certain tags if it already exists - UNSURE whether we should do this.