### PR TITLE
removing tag filtering from home(likes songs) page

### DIFF
--- a/imports/ui/components/SongList.jsx
+++ b/imports/ui/components/SongList.jsx
@@ -23,7 +23,7 @@ class SongList extends Component{
   }
 
   render(){
-    const dataSource = getToggledSongs(this.props.songs, this.props.checkedTags, this.props.andToggle, this.props.filterText);
+    const dataSource = getToggledSongs(this.props.songs, [], this.props.andToggle, this.props.filterText);
 
     return (
       <div id="song-list">


### PR DESCRIPTION
Since songlist isn't checkable anymore, we don't want it to filter out checked tags from the generate page.